### PR TITLE
Fix Android 16 notification auto-grouping

### DIFF
--- a/app/src/main/java/com/maary/liveinpeace/Constants.kt
+++ b/app/src/main/java/com/maary/liveinpeace/Constants.kt
@@ -21,6 +21,7 @@ class Constants {
         const val ID_NOTIFICATION_ALERT = 2
         const val ID_NOTIFICATION_PROTECT = 4
         const val ID_NOTIFICATION_SLEEPTIMER = 5
+        const val ID_NOTIFICATION_GROUP_SUMMARY = 6
         // 静音广播名称
         const val BROADCAST_ACTION_MUTE = "com.maary.liveinpeace.MUTE_MEDIA"
         const val BROADCAST_ACTION_SLEEPTIMER_CANCEL = "com.maary.liveinpeace.action.CANCEL"
@@ -48,10 +49,11 @@ class Constants {
         // 延后时间
         const val THROTTLE_TIME_MS = 100L
         // 不同通知的 GROUP ID
-        const val ID_NOTIFICATION_GROUP_FORE = "LIP_notification_group_foreground"
+        const val ID_NOTIFICATION_GROUP_LIP = "LIP_notification_group_main"
+        const val ID_NOTIFICATION_GROUP_FORE = ID_NOTIFICATION_GROUP_LIP
         const val ID_NOTIFICATION_GROUP_ALERTS = "LIP_notification_group_alerts"
         const val ID_NOTIFICATION_GROUP_PROTECT = "LIP_notification_group_protect"
-        const val ID_NOTIFICATION_GROUP_SLEEPTIMER = "LIP_notification_group_sleeptimer"
+        const val ID_NOTIFICATION_GROUP_SLEEPTIMER = ID_NOTIFICATION_GROUP_LIP
         const val PATTERN_DATE_DATABASE = "yyyy-MM-dd"
         const val PATTERN_DATE_BUTTON = "MM/dd"
 

--- a/app/src/main/java/com/maary/liveinpeace/service/ForegroundService.kt
+++ b/app/src/main/java/com/maary/liveinpeace/service/ForegroundService.kt
@@ -205,6 +205,7 @@ class ForegroundService : Service() {
         stopForeground(STOP_FOREGROUND_REMOVE)
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(Constants.ID_NOTIFICATION_FOREGROUND)
+        notificationManager.cancel(Constants.ID_NOTIFICATION_GROUP_SUMMARY)
 
         Log.d(TAG, "Service destroyed.")
         super.onDestroy()
@@ -527,7 +528,12 @@ class ForegroundService : Service() {
             }
         }
 
-        NotificationManagerCompat.from(this).notify(
+        val notificationManager = NotificationManagerCompat.from(this)
+        notificationManager.notify(
+            Constants.ID_NOTIFICATION_GROUP_SUMMARY,
+            createGroupSummaryNotification(this)
+        )
+        notificationManager.notify(
             Constants.ID_NOTIFICATION_FOREGROUND,
             createForegroundNotification(this)
         )
@@ -666,6 +672,20 @@ class ForegroundService : Service() {
             .setGroup(Constants.ID_NOTIFICATION_GROUP_FORE)
             .addAction(createSettingsAction(context))
             .addAction(createSleepTimerAction(context))
+            .build()
+    }
+
+    private fun createGroupSummaryNotification(context: Context): Notification {
+        val currentVolume = getVolumePercentage()
+        val volumeLevel = getVolumeLevel(currentVolume)
+
+        return NotificationCompat.Builder(this, Constants.CHANNEL_ID_DEFAULT)
+            .setSmallIcon(generateNotificationIcon(context, currentVolume, volumeLevel))
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .setGroup(Constants.ID_NOTIFICATION_GROUP_FORE)
+            .setGroupSummary(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()
     }
 


### PR DESCRIPTION
Fixes the Android 16 notification auto-grouping issue where the volume control and sleep timer were grouped automatically, causing the dynamic volume icon to be hidden.

This is fixed by:
- Creating a shared `Constants.ID_NOTIFICATION_GROUP_LIP` group ID for both the foreground and sleep timer notifications.
- Manually pushing a Group Summary notification (`setGroupSummary(true)`) when updating the volume notification, passing the dynamic volume icon so it stays correctly displayed in the status bar.
- Ensuring this summary notification is removed when the foreground service stops.

---
*PR created automatically by Jules for task [15666467688944342826](https://jules.google.com/task/15666467688944342826) started by @Steve-Mr*